### PR TITLE
Minify: New Line(s) do matter!

### DIFF
--- a/application/libraries/Minify.php
+++ b/application/libraries/Minify.php
@@ -703,6 +703,8 @@ class Minify
 					if (substr(rtrim($contents), -1) !== ';') {
 						$contents .= ';';
 					}
+
+					$contents .= "\n";
 				}
 				fwrite($fh, $contents);
 			}


### PR DESCRIPTION
> If we have a file ending with a single-line comment without a new line, and then the next file begins with a multi-line comment. KABOOM!

1st file:
```
something();
// comment
```

2nd file:
```
/* some
big comment */
something();
```

Concat result:
```something();
// comment;/* some
big comment */
something();
```

Expected concat result:

```something();
// comment;
/* some
big comment */
something();
```

This commit fixes the problem.
Thanks!