### PR TITLE
Update curl request param for Closure compiler.

### DIFF
--- a/application/libraries/Minify.php
+++ b/application/libraries/Minify.php
@@ -761,7 +761,12 @@ class Minify
 		$config = $this->closurecompiler;
 
 		$ch = curl_init('https://closure-compiler.appspot.com/compile');
-
+		
+		//if server is not https
+		if (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == 'off')
+		{
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		}
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_HEADER, 0);


### PR DESCRIPTION
Skip to verify "the peer's SSL certificate" for non SSL server. 
Google clouser compiler will work for SSL and non SSL server both.